### PR TITLE
Add integration metadata fields for group ID, short description, and …

### DIFF
--- a/daml_dit_api/__init__.py
+++ b/daml_dit_api/__init__.py
@@ -40,6 +40,7 @@ class IntegrationTypeInfo:
     env_class: 'Optional[str]'
     runtime: 'Optional[str]' = 'python-file'
     help_url: 'Optional[str]' = None
+    instance_template: 'Optional[str]' = None
 
 
 @dataclass(frozen=True)
@@ -56,6 +57,9 @@ class CatalogInfo:
     demo_url: 'Optional[str]'
     source_url: 'Optional[str]'
     tags: 'Sequence[str]' = field(default_factory=_empty_tags)
+    short_description: 'Optional[str]' = None
+    group_id: 'Optional[str]' = None
+
 
 
 DABL_META_NAME = 'dabl-meta.yaml'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 [tool.poetry]
 name = "daml-dit-api"
-version = "0.0.5"
+version = "0.0.6"
 description = "DABL Integrations API Package"
 authors = ["Mike Schaeffer <mike.schaeffer@digitalasset.com>"]
+readme = "README.md"
 repository = "https://github.com/digital-asset/daml-dit-api"
 keywords = ["daml", "blockchain", "dlt", "distributed ledger", "digital asset"]
 


### PR DESCRIPTION
…the template ID of a contract template used to complete integration configuraton. (ie: for private data that should not be part of the globally visible deployment contract.)