### PR TITLE
Support for additional integration field configuration and the new metadata filename

### DIFF
--- a/daml_dit_api/__init__.py
+++ b/daml_dit_api/__init__.py
@@ -7,6 +7,9 @@ from .package_metadata import \
     CatalogInfo, \
     PackageMetadata, \
     DABL_META_NAME, \
+    DIT_META_NAME, \
+    DIT_META_NAMES, \
+    DIT_META_KEY_NAME, \
     TAG_EXPERIMENTAL, \
     normalize_catalog, \
     normalize_package_metadata, \

--- a/daml_dit_api/package_metadata.py
+++ b/daml_dit_api/package_metadata.py
@@ -65,6 +65,10 @@ class DamlModelInfo:
     main_package_id: str
 
 
+# Key name used to identify DIT metadata bundled into daml.yaml
+DIT_META_KEY_NAME = 'dit-meta'
+
+# The original and current names of the DIT metadata subfile.
 DABL_META_NAME = 'dabl-meta.yaml'
 DIT_META_NAME = 'dit-meta.yaml'
 

--- a/daml_dit_api/package_metadata.py
+++ b/daml_dit_api/package_metadata.py
@@ -21,6 +21,7 @@ class IntegrationTypeFieldInfo:
     default_value: 'Optional[str]' = None
     required: 'Optional[bool]' = True
     tags: 'Sequence[str]' = field(default_factory=_empty_tags)
+    field_context: 'Optional[str]' = None
 
 
 @dataclass(frozen=True)
@@ -65,7 +66,10 @@ class DamlModelInfo:
 
 
 DABL_META_NAME = 'dabl-meta.yaml'
+DIT_META_NAME = 'dit-meta.yaml'
 
+# Lookup names for package metadata. Listed in search order.
+DIT_META_NAMES = [ DIT_META_NAME, DABL_META_NAME ]
 
 @dataclass(frozen=True)
 class PackageMetadata:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "daml-dit-api"
-version = "0.4.3"
+version = "0.4.4"
 description = "Daml Hub DIT File API Package"
 authors = ["Mike Schaeffer <mike.schaeffer@digitalasset.com>"]
 readme = "README.md"


### PR DESCRIPTION
* Add the name of the new DIT metadata subfile
* Add a list of metadata subfile names in search order.
* Add a way to annotate integration control fields with context info that can control how they are rendered/required. (Not yet implemented in any way, but the general gist is to use this to make fields optional/etc. based on the values stored in other fields. The existing `required` flag will be subordinate to this to the extent that a field cannot exactly be required if it doesn't apply at all to a given mode.)