### PR TITLE
Add a catalog field to allow a DIT file to explicitly state it requires  a given version of `daml-dit-if`.

### DIFF
--- a/daml_dit_api/package_metadata.py
+++ b/daml_dit_api/package_metadata.py
@@ -56,6 +56,7 @@ class CatalogInfo:
     short_description: 'Optional[str]' = None
     group_id: 'Optional[str]' = None
     icon_file: 'Optional[str]' = None
+    dit_if_requirement: 'Optional[str]' = None
 
 
 @dataclass(frozen=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "daml-dit-api"
-version = "0.4.4"
+version = "0.4.5"
 description = "Daml Hub DIT File API Package"
 authors = ["Mike Schaeffer <mike.schaeffer@digitalasset.com>"]
 readme = "README.md"


### PR DESCRIPTION
This new field will be able to accept the minimum required version of `daml-dit-if` for a given DIT file. Daml Hub to be modified to use this to prevent unsupported integration version from being shown in the arcade.